### PR TITLE
Add word-break: keep-all to CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@ body {
 	padding:10px;
 	text-align: justify;
 	text-justify: inter-word;
+	word-break: keep-all
 }
 
 .small {

--- a/s2e01.html
+++ b/s2e01.html
@@ -14,6 +14,7 @@ body,td,tr {
 	padding:10px;
 	text-align: justify;
 	text-justify: inter-word;
+	word-break: keep-all
 }
 
 h1, h2 {

--- a/s2e02.html
+++ b/s2e02.html
@@ -14,6 +14,7 @@ body,td,tr {
 	padding:10px;
 	text-align: justify;
 	text-justify: inter-word;
+	word-break: keep-all
 }
 
 h1, h2 {

--- a/s2e03.html
+++ b/s2e03.html
@@ -14,6 +14,7 @@ body,td,tr {
 	padding:10px;
 	text-align: justify;
 	text-justify: inter-word;
+	word-break: keep-all
 }
 
 h1, h2 {

--- a/s2e04.html
+++ b/s2e04.html
@@ -14,6 +14,7 @@ body,td,tr {
 	padding:10px;
 	text-align: justify;
 	text-justify: inter-word;
+	word-break: keep-all
 }
 
 h1, h2 {

--- a/s2e05.html
+++ b/s2e05.html
@@ -14,6 +14,7 @@ body,td,tr {
 	padding:10px;
 	text-align: justify;
 	text-justify: inter-word;
+	word-break: keep-all
 }
 
 h1, h2 {

--- a/s2e06.html
+++ b/s2e06.html
@@ -14,6 +14,7 @@ body,td,tr {
 	padding:10px;
 	text-align: justify;
 	text-justify: inter-word;
+	word-break: keep-all
 }
 
 h1, h2 {

--- a/s2e07.html
+++ b/s2e07.html
@@ -14,6 +14,7 @@ body,td,tr {
 	padding:10px;
 	text-align: justify;
 	text-justify: inter-word;
+	word-break: keep-all
 }
 
 h1, h2 {

--- a/s2e08.html
+++ b/s2e08.html
@@ -14,6 +14,7 @@ body,td,tr {
 	padding:10px;
 	text-align: justify;
 	text-justify: inter-word;
+	word-break: keep-all
 }
 
 h1, h2 {

--- a/s2e09.html
+++ b/s2e09.html
@@ -14,6 +14,7 @@ body,td,tr {
 	padding:10px;
 	text-align: justify;
 	text-justify: inter-word;
+	word-break: keep-all
 }
 
 h1, h2 {

--- a/s2e10.html
+++ b/s2e10.html
@@ -14,6 +14,7 @@ body,td,tr {
 	padding:10px;
 	text-align: justify;
 	text-justify: inter-word;
+	word-break: keep-all
 }
 
 h1, h2 {

--- a/s2e11.html
+++ b/s2e11.html
@@ -14,6 +14,7 @@ body,td,tr {
 	padding:10px;
 	text-align: justify;
 	text-justify: inter-word;
+	word-break: keep-all
 }
 
 h1, h2 {

--- a/s2e12.html
+++ b/s2e12.html
@@ -14,6 +14,7 @@ body,td,tr {
 	padding:10px;
 	text-align: justify;
 	text-justify: inter-word;
+	word-break: keep-all
 }
 
 h1, h2 {


### PR DESCRIPTION
This disables mid-word line breaks in words. The default for Chinese/Japanese/Korean text is to line break mid-word, but this is quite annoying, especially when learning because it's not clear where the word boundaries are. For more info see: https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#Values